### PR TITLE
enabling decode a telemetry frame

### DIFF
--- a/crossfire/crossfire.py
+++ b/crossfire/crossfire.py
@@ -723,6 +723,7 @@ class Crsf:
         if self._state == self.State.SYNC:
             if data == const.CRSF_ADDRESS_CRSF_RECEIVER or \
                     data == const.CRSF_ADDRESS_CRSF_TRANSMITTER or \
+                    data == const.CRSF_ADDRESS_RADIO_TRANSMITTER or \
                     data == const.CRSF_SYNC_BYTE or \
                     data == const.CRSF_ADDRESS_BROADCAST:
                 self._state = self.State.LENGTH


### PR DESCRIPTION
CRSF_ADDRESS_RADIO_TRANSMITTER should also be added for the sync word for decoding a radio telemetry frame.